### PR TITLE
Allow client to get the current scroll position and an array with the split content

### DIFF
--- a/src/scrollable.ts
+++ b/src/scrollable.ts
@@ -41,7 +41,7 @@ export type ScrollableOptions = {
  */
 export class Scrollable {
     private _lines: string[] = [];
-    private _currentLine = 0;
+    private _position = 0;
     private _options: ScrollableOptions;
 
     /**
@@ -49,6 +49,21 @@ export class Scrollable {
      */
     get options(): ScrollableOptions {
         return this._options;
+    }
+
+    /**
+     * The lines of content in the scrollable area 
+     * wrapped according to {@link ScrollableOptions.wrapOptions} and split into an array of lines.
+     */
+    get lines(): string[] {
+        return this._lines;
+    }
+
+    /**
+     * The position of the first line to display in the scrollable area.
+     */
+    get position(): number {
+        return this._position;
     }
 
     /**
@@ -141,7 +156,7 @@ export class Scrollable {
 
         stdout.cursorTo(x, y);
         for (let i = 0; i < height; i++) {
-            const line = this._lines[i + this._currentLine];
+            const line = this._lines[i + this._position];
             stdout.cursorTo(x);
 
             stdout.write((line ?? emptyLine) + '\n');
@@ -156,7 +171,7 @@ export class Scrollable {
      * @returns The Scrollable instance.
      */
     scroll(lines: number): this {
-        this._currentLine += lines;
+        this._position += lines;
         return this;
     }
 
@@ -181,7 +196,7 @@ export class Scrollable {
 
     private resetLines(): void {
         this._lines = [];
-        this._currentLine = 0;
+        this._position = 0;
     }
 
     private splitContentIntoLines(): void {

--- a/src/scrollable.ts
+++ b/src/scrollable.ts
@@ -40,8 +40,8 @@ export type ScrollableOptions = {
  * A scrollable area that can be printed to the console.
  */
 export class Scrollable {
-    private lines: string[] = [];
-    private currentLine = 0;
+    private _lines: string[] = [];
+    private _currentLine = 0;
     private _options: ScrollableOptions;
 
     /**
@@ -130,7 +130,7 @@ export class Scrollable {
      * @returns The Scrollable instance.
      */
     print(): this {
-        if (this.lines.length == 0) this.splitContentIntoLines();
+        if (this._lines.length == 0) this.splitContentIntoLines();
         const { x, y } = this._options.start;
         const { width, height } = this._options.size;
         const emptyLine = Array(width).fill(' ').join('');
@@ -141,7 +141,7 @@ export class Scrollable {
 
         stdout.cursorTo(x, y);
         for (let i = 0; i < height; i++) {
-            const line = this.lines[i + this.currentLine];
+            const line = this._lines[i + this._currentLine];
             stdout.cursorTo(x);
 
             stdout.write((line ?? emptyLine) + '\n');
@@ -156,7 +156,7 @@ export class Scrollable {
      * @returns The Scrollable instance.
      */
     scroll(lines: number): this {
-        this.currentLine += lines;
+        this._currentLine += lines;
         return this;
     }
 
@@ -180,8 +180,8 @@ export class Scrollable {
     }
 
     private resetLines(): void {
-        this.lines = [];
-        this.currentLine = 0;
+        this._lines = [];
+        this._currentLine = 0;
     }
 
     private splitContentIntoLines(): void {
@@ -192,6 +192,6 @@ export class Scrollable {
             this._options.size.width,
             this._options.wrapOptions
         );
-        this.lines = wrapped.split('\n');
+        this._lines = wrapped.split('\n');
     }
 }

--- a/src/scrollable.ts
+++ b/src/scrollable.ts
@@ -53,7 +53,7 @@ export class Scrollable {
 
     /**
      * The lines of content in the scrollable area 
-     * wrapped according to {@link ScrollableOptions.wrapOptions} and split into an array of lines.
+     * wrapped according to the specified {@link ScrollableOptions} and split into an array of lines.
      */
     get lines(): string[] {
         return this._lines;

--- a/tests/scrollable.test.ts
+++ b/tests/scrollable.test.ts
@@ -9,6 +9,70 @@ describe('Scrollable', () => {
         scrollable = new Scrollable({ stdout: createFakeStdout() });
     });
 
+    describe('get position', () => {
+        it('should return the current position of the scrollable area', () => {
+            scrollable.setContent(
+                'Lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod'
+            );
+
+            scrollable.scroll(1);
+            expect(scrollable.position).to.equal(1);
+
+            scrollable.scroll(-2);
+            expect(scrollable.position).to.equal(-1);
+
+            scrollable.scroll(5);
+            expect(scrollable.position).to.equal(4);
+        });
+    });
+
+    describe('get lines', () => {
+        it('should return all the lines of the content in an array', () => {
+            scrollable
+                .setContent('Lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod')
+                .setSize({ width: 12, height: 3 })
+                .print();
+
+            expect(scrollable.lines).to.be.an('array').that.has.lengthOf(7);
+            expect(scrollable.lines[0]).to.equal('Lorem ipsum');
+            expect(scrollable.lines[1]).to.equal('dolor sit');
+            expect(scrollable.lines[2]).to.equal('amet');
+            expect(scrollable.lines[3]).to.equal('consectetur');
+            expect(scrollable.lines[4]).to.equal('adipiscing');
+            expect(scrollable.lines[5]).to.equal('elit sed do');
+            expect(scrollable.lines[6]).to.equal('eiusmod');           
+        });
+
+        it('should return all the lines of the content in an array considering newlines', () => {
+            scrollable
+                .setContent('Lorem \nipsum dolor sit\n amet consectetur')
+                .setSize({ width: 12, height: 3 })
+                .print();
+
+            expect(scrollable.lines).to.be.an('array').that.has.lengthOf(5);
+            expect(scrollable.lines[0]).to.equal('Lorem');
+            expect(scrollable.lines[1]).to.equal('ipsum dolor');
+            expect(scrollable.lines[2]).to.equal('sit');
+            expect(scrollable.lines[3]).to.equal('amet');
+            expect(scrollable.lines[4]).to.equal('consectetur');
+        });
+
+        it('should return all the lines of the content after scrolling', () => {
+            scrollable
+                .setContent('Lorem ipsum dolor sit amet consectetur')
+                .setSize({ width: 12, height: 3 })
+                .print();
+
+            scrollable.scroll(4);
+
+            expect(scrollable.lines).to.be.an('array').that.has.lengthOf(4);
+            expect(scrollable.lines[0]).to.equal('Lorem ipsum');
+            expect(scrollable.lines[1]).to.equal('dolor sit');
+            expect(scrollable.lines[2]).to.equal('amet');
+            expect(scrollable.lines[3]).to.equal('consectetur');
+        });
+    });
+
     describe('print', () => {
         let spyWrite: SinonSpy;
 
@@ -100,13 +164,13 @@ describe('Scrollable', () => {
             );
 
             scrollable.scroll(1);
-            expect(scrollable['currentLine']).to.equal(1);
+            expect(scrollable['_position']).to.equal(1);
 
             scrollable.scroll(-2);
-            expect(scrollable['currentLine']).to.equal(-1);
+            expect(scrollable['_position']).to.equal(-1);
 
             scrollable.scroll(5);
-            expect(scrollable['currentLine']).to.equal(4);
+            expect(scrollable['_position']).to.equal(4);
         });
 
         it('should print the correct lines after scrolling down', () => {


### PR DESCRIPTION

- Renames private field `lines` to `_lines`
- Renames private field `currentLine` to `_position`
- Adds public getters for `_position` and `_lines`

Closes #5 